### PR TITLE
Category collection does not have setStore method

### DIFF
--- a/Model/Product/Sync.php
+++ b/Model/Product/Sync.php
@@ -3094,7 +3094,7 @@ class Sync extends \Klevu\Search\Model\Sync {
             $category_ids[] = $value["category_id"];
         }
         $category_data = $this->_catalogModelCategory->getCollection()
-		->setStore($this->_storeModelStoreManagerInterface->getStore())
+		->setStoreId($this->_storeModelStoreManagerInterface->getStore()->getId())
 		->addAttributeToSelect("*")->addFieldToFilter('entity_id', array(
             'in' => $category_ids
         ));


### PR DESCRIPTION
```
root@server-xxxx:/var/www/xxxxx# sudo -H -u www-data php bin/magento klevu:syncdata
PHP Fatal error:  Uncaught Error: Call to undefined method Magento\Catalog\Model\ResourceModel\Category\Flat\Collection::setStore() in /var/www/xxxxx/vendor/klevu/module-productsearch/Model/Product/Sync.php:3097
```

Category collection (flat or not) does not have `setStore` method, only `setStoreId`.