### PR TITLE
fix sql ORDERBY so that FIELD content will not be escaped

### DIFF
--- a/Model/ResourceModel/Fulltext/Collection.php
+++ b/Model/ResourceModel/Fulltext/Collection.php
@@ -18,7 +18,7 @@ class Collection
      * @var \Magento\Framework\App\RequestInterface
      */
     protected $request;
-	
+
 	/**
      * @param RequestInterface $request
      */
@@ -35,15 +35,15 @@ class Collection
 			$collection_order = $this->request->getParam('product_list_order');
 			$module_name = $this->request->getModuleName();
 			if(empty($collection_order) && !empty($session->getData('ids')) && $module_name == "catalogsearch") {
-				$collection->getSelect()->order(sprintf('FIELD(`e`.`entity_id`, %s) ASC', implode(',', $session->getData('ids'))));
+				$collection->getSelect()->order(new \Zend_Db_Expr(sprintf('FIELD(`e`.`entity_id`, %s) ASC', implode(',', $session->getData('ids')))));
 			} else {
 				if($collection_order == 'relevance' && !empty($session->getData('ids')) && $module_name == "catalogsearch"){
-					$collection->getSelect()->order(sprintf('FIELD(`e`.`entity_id`, %s) ASC', implode(',', $session->getData('ids'))));
+					$collection->getSelect()->order(new \Zend_Db_Expr(sprintf('FIELD(`e`.`entity_id`, %s) ASC', implode(',', $session->getData('ids')))));
 				}
 			}
 			return $collection;
 		}
-		
-       
+
+
     }
 }


### PR DESCRIPTION
When request was made to catalogsearch/result/?q=<some_word> then instead of results it showed SQL on result page.

What was strange in SQL was the ORDER BY :

    ORDER BY `FIELD(``e```.```entity_id``, 1702,873,930,906,1789,882,2156,888,1864,2155,942,1690,909,843,900,699,894,921,855,2165,918,885,2168,852,702,870,903,933,927,846,1861,924)` ASC

As you can see from here then FIELD with it's content is escaped therefor it gives

    Unknown column 'FIELD(`e`.`entity_id`, 1702,873,930,906,1789,882,2156,888,1864,2155,942,1690,909,843,900,699,894,921,855,2165,918,885,2168,852,702,870,903,933,927,846,1861,924' in 'order clause'

Wrapped with "new \ Zend_Db_Expr".