### PR TITLE
Fix reference to UI library for improved performance

### DIFF
--- a/view/frontend/web/js/disableautosuggest.js
+++ b/view/frontend/web/js/disableautosuggest.js
@@ -1,6 +1,6 @@
 define([
   'jquery',
-  'jquery/ui',
+  'jquery-ui-modules/widget',
   'Magento_Search/form-mini' 
 ], function($){
  


### PR DESCRIPTION
Currently, Klevu causes the entire UI library to load.

Magento updated jQuery UI in 2.3.4 (Ref original PR: https://github.com/magento/magento2/issues/22995) to use each library separately to reduce FE load. When a JS file still references UI library the old way (as is currently the case in this repo) this causes a compatibility file to trigger the download of the whole UI library, adding as much as 120kb additional JS to the network requests.

This fix ensures only the widget library loads. I've not observed any difference in behaviour of the search but obviously would need thorough testing.