### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository.

### DIFF
--- a/Block/Search/Index/Sync.php
+++ b/Block/Search/Index/Sync.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Klevu\Search\Block\Search\Index;
+
+use Klevu\Search\Block\Search\Index as IndexBlock;
+use Magento\Framework\View\Element\Template;
+
+class Sync extends IndexBlock
+{
+    /**
+     * @return string
+     */
+    protected function _toHtml()
+    {
+        // Skip direct parent which checks for JSv2 configuration
+        //  to prevent backend blocks not displaying when JSv2 enabled
+        return Template::_toHtml();
+    }
+}

--- a/Test/Integration/Block/Search/Index/SyncTest.php
+++ b/Test/Integration/Block/Search/Index/SyncTest.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Klevu\Search\Test\Integration\Block\Search\Index;
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager;
+use Magento\TestFramework\TestCase\AbstractController as AbstractControllerTestCase;
+
+class SyncTest extends AbstractControllerTestCase
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @@magentoAppArea frontend
+     * @magentoCache all disabled
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation disabled
+     * @magentoConfigFixture default_store klevu_search/general/js_api_key
+     * @magentoConfigFixture default_store klevu_search/general/rest_api_key
+     * @magentoConfigFixture default/klevu_search/developer/theme_version v1
+     * @magentoConfigFixture default_store klevu_search/developer/theme_version v1
+     */
+    public function testSyncstoreOutput_ThemeV1_NotIntegrated()
+    {
+        $this->setupPhp5();
+
+        $this->dispatch('search/index/syncstore/store/1/hashkey/' . hash('sha256', 'ABCDE12345'));
+
+        $response = $this->getResponse();
+        $responseBody = $response->getBody();
+        $this->assertSame(200, $response->getHttpResponseCode());
+
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString('Manually Data Sync', $responseBody);
+            $this->assertStringContainsString('function callAjaxRecurrsively()', $responseBody);
+            $this->assertStringContainsString('Hash key found invalid for requested store.', $responseBody);
+        } else {
+            $this->assertContains('Manually Data Sync', $responseBody);
+            $this->assertContains('function callAjaxRecurrsively()', $responseBody);
+            $this->assertContains('Hash key found invalid for requested store.', $responseBody);
+        }
+
+        if (method_exists($this, 'assertDoesNotMatchRegularExpression')) {
+            $this->assertDoesNotMatchRegularExpression("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        } else {
+            $this->assertNotRegExp("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        }
+
+        if (method_exists($this, 'assertStringNotContainsString')) {
+            $this->assertStringNotContainsString('klevu.interactive', $responseBody);
+        } else {
+            $this->assertNotContains('klevu.interactive', $responseBody);
+        }
+    }
+
+    /**
+     * @@magentoAppArea frontend
+     * @magentoCache all disabled
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation disabled
+     * @magentoConfigFixture default_store klevu_search/general/js_api_key klevu-1234567890
+     * @magentoConfigFixture default_store klevu_search/general/rest_api_key ABCDE12345
+     * @magentoConfigFixture default/klevu_search/developer/theme_version v1
+     * @magentoConfigFixture default_store klevu_search/developer/theme_version v1
+     */
+    public function testSyncstoreOutput_ThemeV1_Integrated()
+    {
+        $this->setupPhp5();
+
+        $this->dispatch('search/index/syncstore/store/1/hashkey/' . hash('sha256', 'ABCDE12345'));
+
+        $response = $this->getResponse();
+        $responseBody = $response->getBody();
+        $this->assertSame(200, $response->getHttpResponseCode());
+
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString('Manually Data Sync', $responseBody);
+            $this->assertStringContainsString('function callAjaxRecurrsively()', $responseBody);
+        } else {
+            $this->assertContains('Manually Data Sync', $responseBody);
+            $this->assertContains('function callAjaxRecurrsively()', $responseBody);
+        }
+
+        if (method_exists($this, 'assertDoesNotMatchRegularExpression')) {
+            $this->assertMatchesRegularExpression("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        } else {
+            $this->assertRegExp("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        }
+
+        if (method_exists($this, 'assertStringNotContainsString')) {
+            $this->assertStringNotContainsString('Hash key found invalid for requested store.', $responseBody);
+            $this->assertStringNotContainsString('klevu.interactive', $responseBody);
+        } else {
+            $this->assertNotContains('Hash key found invalid for requested store.', $responseBody);
+            $this->assertNotContains('klevu.interactive', $responseBody);
+        }
+    }
+
+    /**
+     * @@magentoAppArea frontend
+     * @magentoCache all disabled
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation disabled
+     * @magentoConfigFixture default_store klevu_search/general/js_api_key klevu-1234567890
+     * @magentoConfigFixture default_store klevu_search/general/rest_api_key ABCDE12345
+     * @magentoConfigFixture default/klevu_search/developer/theme_version v1
+     * @magentoConfigFixture default_store klevu_search/developer/theme_version v1
+     */
+    public function testSyncstoreOutput_ThemeV1_Integrated_InvalidKey()
+    {
+        $this->setupPhp5();
+
+        $this->dispatch('search/index/syncstore/store/1/hashkey/' . hash('sha256', 'FGHIJ67890'));
+
+        $response = $this->getResponse();
+        $responseBody = $response->getBody();
+        $this->assertSame(200, $response->getHttpResponseCode());
+
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString('Manually Data Sync', $responseBody);
+            $this->assertStringContainsString('function callAjaxRecurrsively()', $responseBody);
+            $this->assertStringContainsString('Hash key found invalid for requested store.', $responseBody);
+        } else {
+            $this->assertContains('Manually Data Sync', $responseBody);
+            $this->assertContains('function callAjaxRecurrsively()', $responseBody);
+            $this->assertContains('Hash key found invalid for requested store.', $responseBody);
+        }
+
+        if (method_exists($this, 'assertDoesNotMatchRegularExpression')) {
+            $this->assertDoesNotMatchRegularExpression("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        } else {
+            $this->assertNotRegExp("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        }
+
+        if (method_exists($this, 'assertStringNotContainsString')) {
+            $this->assertStringNotContainsString('klevu.interactive', $responseBody);
+        } else {
+            $this->assertNotContains('klevu.interactive', $responseBody);
+        }
+    }
+
+    /**
+     * @@magentoAppArea frontend
+     * @magentoCache all disabled
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation disabled
+     * @magentoConfigFixture default_store klevu_search/general/js_api_key
+     * @magentoConfigFixture default_store klevu_search/general/rest_api_key
+     * @magentoConfigFixture default/klevu_search/developer/theme_version v2
+     * @magentoConfigFixture default_store klevu_search/developer/theme_version v2
+     */
+    public function testSyncstoreOutput_ThemeV2_NotIntegrated()
+    {
+        $this->setupPhp5();
+
+        $this->dispatch('search/index/syncstore/store/1/hashkey/' . hash('sha256', 'ABCDE12345'));
+
+        $response = $this->getResponse();
+        $responseBody = $response->getBody();
+        $this->assertSame(200, $response->getHttpResponseCode());
+
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString('Manually Data Sync', $responseBody);
+            $this->assertStringContainsString('function callAjaxRecurrsively()', $responseBody);
+            $this->assertStringContainsString('Hash key found invalid for requested store.', $responseBody);
+        } else {
+            $this->assertContains('Manually Data Sync', $responseBody);
+            $this->assertContains('function callAjaxRecurrsively()', $responseBody);
+            $this->assertContains('Hash key found invalid for requested store.', $responseBody);
+        }
+
+        if (method_exists($this, 'assertDoesNotMatchRegularExpression')) {
+            $this->assertDoesNotMatchRegularExpression("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        } else {
+            $this->assertNotRegExp("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        }
+
+        if (method_exists($this, 'assertStringNotContainsString')) {
+            $this->assertStringNotContainsString('klevu.interactive', $responseBody);
+        } else {
+            $this->assertNotContains('klevu.interactive', $responseBody);
+        }
+    }
+
+    /**
+     * @@magentoAppArea frontend
+     * @magentoCache all disabled
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation disabled
+     * @magentoConfigFixture default_store klevu_search/general/js_api_key klevu-1234567890
+     * @magentoConfigFixture default_store klevu_search/general/rest_api_key ABCDE12345
+     * @magentoConfigFixture default/klevu_search/developer/theme_version v2
+     * @magentoConfigFixture default_store klevu_search/developer/theme_version v2
+     */
+    public function testSyncstoreOutput_ThemeV2_Integrated()
+    {
+        $this->setupPhp5();
+
+        $this->dispatch('search/index/syncstore/store/1/hashkey/' . hash('sha256', 'ABCDE12345'));
+
+        $response = $this->getResponse();
+        $responseBody = $response->getBody();
+        $this->assertSame(200, $response->getHttpResponseCode());
+
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString('Manually Data Sync', $responseBody);
+            $this->assertStringContainsString('function callAjaxRecurrsively()', $responseBody);
+        } else {
+            $this->assertContains('Manually Data Sync', $responseBody);
+            $this->assertContains('function callAjaxRecurrsively()', $responseBody);
+        }
+
+        if (method_exists($this, 'assertDoesNotMatchRegularExpression')) {
+            $this->assertMatchesRegularExpression("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        } else {
+            $this->assertRegExp("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        }
+
+        if (method_exists($this, 'assertStringNotContainsString')) {
+            $this->assertStringNotContainsString('Hash key found invalid for requested store.', $responseBody);
+            $this->assertStringNotContainsString('klevu.interactive', $responseBody);
+        } else {
+            $this->assertNotContains('Hash key found invalid for requested store.', $responseBody);
+            $this->assertNotContains('klevu.interactive', $responseBody);
+        }
+    }
+
+    /**
+     * @@magentoAppArea frontend
+     * @magentoCache all disabled
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation disabled
+     * @magentoConfigFixture default_store klevu_search/general/js_api_key klevu-1234567890
+     * @magentoConfigFixture default_store klevu_search/general/rest_api_key ABCDE12345
+     * @magentoConfigFixture default/klevu_search/developer/theme_version v2
+     * @magentoConfigFixture default_store klevu_search/developer/theme_version v2
+     */
+    public function testSyncstoreOutput_ThemeV2_Integrated_InvalidKey()
+    {
+        $this->setupPhp5();
+
+        $this->dispatch('search/index/syncstore/store/1/hashkey/' . hash('sha256', 'FGHIJ67890'));
+
+        $response = $this->getResponse();
+        $responseBody = $response->getBody();
+        $this->assertSame(200, $response->getHttpResponseCode());
+
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString('Manually Data Sync', $responseBody);
+            $this->assertStringContainsString('function callAjaxRecurrsively()', $responseBody);
+            $this->assertStringContainsString('Hash key found invalid for requested store.', $responseBody);
+        } else {
+            $this->assertContains('Manually Data Sync', $responseBody);
+            $this->assertContains('function callAjaxRecurrsively()', $responseBody);
+            $this->assertContains('Hash key found invalid for requested store.', $responseBody);
+        }
+
+        if (method_exists($this, 'assertDoesNotMatchRegularExpression')) {
+            $this->assertDoesNotMatchRegularExpression("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        } else {
+            $this->assertNotRegExp("#require\(\['jquery'\], function\(\) {\s*callAjaxRecurrsively\(\);\s*}\);#m", $responseBody);
+        }
+
+        if (method_exists($this, 'assertStringNotContainsString')) {
+            $this->assertStringNotContainsString('klevu.interactive', $responseBody);
+        } else {
+            $this->assertNotContains('klevu.interactive', $responseBody);
+        }
+    }
+
+    /**
+     * @return void
+     * @todo Move to setUp when PHP 5.x is no longer supported
+     */
+    private function setupPhp5()
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "klevu/module-metadata": "^1.1.0"
     },
     "type": "magento-module",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/view/frontend/layout/search_index_runexternaly.xml
+++ b/view/frontend/layout/search_index_runexternaly.xml
@@ -2,7 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="empty" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="content">
-            <block class="Klevu\Search\Block\Search\Index" template="Klevu_Search::klevu/search/klevulog.phtml" name="search_index_logreceiver"/>
+            <block class="Klevu\Search\Block\Search\Index\Sync" template="Klevu_Search::klevu/search/klevulog.phtml" name="search_index_logreceiver"/>
         </referenceBlock>
     </body>
 </page>

--- a/view/frontend/layout/search_index_syncstore.xml
+++ b/view/frontend/layout/search_index_syncstore.xml
@@ -15,7 +15,14 @@
         <referenceContainer name="footer-container"  remove="true"/>
 
         <referenceBlock name="content">
-            <block class="Klevu\Search\Block\Search\Index" template="Klevu_Search::klevu/search/ajaxsync.phtml" name="search_index_syncstore"/>
+            <block class="Klevu\Search\Block\Search\Index\Sync" template="Klevu_Search::klevu/search/ajaxsync.phtml" name="search_index_syncstore"/>
         </referenceBlock>
+
+        <referenceBlock name="klevu_search.html_head.themev2.js_variables" remove="true"/>
+        <referenceBlock name="klevu_frontendjs.js_includes.core" remove="true"/>
+        <referenceBlock name="klevu_frontendjs.js_api_keys" remove="true"/>
+        <referenceBlock name="klevu_frontendjs.js_init" remove="true"/>
+        <referenceBlock name="klevu_frontendjs.js_includes" remove="true"/>
+        <referenceBlock name="klevu_search.search.css_includes" remove="true"/>
     </body>
 </page>

--- a/view/frontend/layout/search_search_runexternalylog.xml
+++ b/view/frontend/layout/search_search_runexternalylog.xml
@@ -3,7 +3,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="content">
-            <block class="Klevu\Search\Block\Search\Index" template="Klevu_Search::klevu/search/klevulog.phtml" name="search_index_runexternalylog"/>
+            <block class="Klevu\Search\Block\Search\Index\Sync" template="Klevu_Search::klevu/search/klevulog.phtml" name="search_index_runexternalylog"/>
         </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
It is to enable indexing of products with Klevu Search. This is a mandatory package.

Please, see klevu-smart-search-M2/README.md for more information on how to install the overall extension.