### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository.

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -196,7 +196,7 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Return the configuration flag for sending config image.
      *
-     * @param Mage_Core_Model_Store|int $store
+     * @param $store_id
      *
      * @return bool
      */
@@ -422,12 +422,16 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     /**
-     * @param null $store
+     * @param int|StoreInterface|null $store
      * @return string
      */
-    public function getAnalyticsUrl()
+    public function getAnalyticsUrl($store = null)
     {
-        $url = $this->_appConfigScopeConfigInterface->getValue(static::XML_PATH_ANALYTICS_URL);
+        $url = $this->_appConfigScopeConfigInterface->getValue(
+        	static::XML_PATH_ANALYTICS_URL,
+        	\Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+        	$store
+        );
         return ($url) ? $url : ApiHelper::ENDPOINT_DEFAULT_ANALYTICS_HOSTNAME;
     }
 
@@ -682,11 +686,17 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Check if default Magento log settings should be overridden to force logging for this module.
      *
+     * @param int $store
      * @return bool
+     * @deprecated
      */
-    public function isLoggingForced()
+    public function isLoggingForced($store = null)
     {
-        return $this->_appConfigScopeConfigInterface->isSetFlag(static::XML_PATH_FORCE_LOG);
+        return $this->_appConfigScopeConfigInterface->isSetFlag(
+            static::XML_PATH_FORCE_LOG,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
     }
 
     /**
@@ -1188,10 +1198,9 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
 
 
 	/**
-     * Return Catalog Visibity Sync.
+     * Return Catalog Visibility Sync.
      *
-     * @param Mage_Core_Model_Store|int $store
-     *
+     * @param null $store_id
      * @return bool
      */
     public function useCatalogVisibitySync($store_id = null)
@@ -1200,9 +1209,7 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     /**
-     * Return Catalog Visibity Sync.
-     *
-     * @param Mage_Core_Model_Store|int $store
+     * Return Current Configured Catalog search engine.
      *
      * @return bool
      */
@@ -1336,14 +1343,19 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
 
         return (int)$this->_appConfigScopeConfigInterface->getValue(static::XML_PATH_NOTIFICATION_LOCK_FILE, ScopeInterface::SCOPE_STORE, $store);
     }
-	/**
+    /**
      * Check if Klevu preserve layout log enabled in settings
      *
+     * @param int $store
      * @return bool
      */
-    public function isPreserveLayoutLogEnabled()
+    public function isPreserveLayoutLogEnabled($store = null)
     {
-        return $this->_appConfigScopeConfigInterface->isSetFlag(static::XML_PATH_PRESERVE_LAYOUT_LOG_ENABLED);
+        return $this->_appConfigScopeConfigInterface->isSetFlag(
+            static::XML_PATH_PRESERVE_LAYOUT_LOG_ENABLED,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
     }
     /**
      * Returns notification flag for lock file warning

--- a/Plugin/Api/Search/SearchResult.php
+++ b/Plugin/Api/Search/SearchResult.php
@@ -33,8 +33,13 @@ class SearchResult
      *
      * @param Registry $registry
      * @param KlevuConfig $klevuConfig
+     * @param KlevuHelperData $klevuHelperData
      */
-    public function __construct(Registry $registry, KlevuConfig $klevuConfig, KlevuHelperData $klevuHelperData)
+    public function __construct(
+        Registry              $registry,
+        KlevuConfig           $klevuConfig,
+        KlevuHelperData       $klevuHelperData
+    )
     {
         $this->registry = $registry;
         $this->klevuConfig = $klevuConfig;
@@ -48,17 +53,17 @@ class SearchResult
      */
     public function beforeSetItems(
         \Magento\Framework\Api\Search\SearchResult $subject,
-        $result)
+                                                   $result)
     {
         $current_order = $this->registry->registry('current_order');
         $klReqCleanerType = $this->registry->registry('klReqCleanerType');
         if ($this->klevuConfig->isPreserveLayoutLogEnabled()) {
             $process = rand(100000, 999999);
             $this->writeToPreserveLayoutLog(
-                $process . sprintf(" searchResultPlugin:: currentRegistryOrder-%s", $current_order)
+                $process . sprintf(" searchResultPlugin:: currentRegistryOrder: [%s]", $current_order)
             );
             $this->writeToPreserveLayoutLog(
-                $process . sprintf(" searchResultPlugin:: RequestType-%s", $klReqCleanerType)
+                $process . sprintf(" searchResultPlugin:: RequestType: [%s]", $klReqCleanerType)
             );
         }
         if (!empty($current_order)) {
@@ -161,5 +166,5 @@ class SearchResult
     {
         $this->klevuHelperData->preserveLayoutLog($message);
     }
-}
 
+}

--- a/Service/ThemeV2/InteractiveOptionsProvider.php
+++ b/Service/ThemeV2/InteractiveOptionsProvider.php
@@ -27,9 +27,10 @@ class InteractiveOptionsProvider implements InteractiveOptionsProviderInterface
      * @param IsEnabledConditionInterface $isEnabledCondition
      */
     public function __construct(
-        ScopeConfigInterface $scopeConfig,
+        ScopeConfigInterface        $scopeConfig,
         IsEnabledConditionInterface $isEnabledCondition
-    ) {
+    )
+    {
         $this->scopeConfig = $scopeConfig;
         $this->isEnabledCondition = $isEnabledCondition;
     }
@@ -71,10 +72,11 @@ class InteractiveOptionsProvider implements InteractiveOptionsProviderInterface
 
         return [
             'url' => [
+                'protocol' => 'https',
                 'landing' => (int)$landingUri === Landingoptions::KlEVULAND
                     ? '/search'
                     : '/catalogsearch/result',
-                'search' => sprintf('//%s/cs/v2/search', $cloudSearchUrl),
+                'search' => sprintf('https://%s/cs/v2/search', $cloudSearchUrl),
             ],
             'search' => [
                 'minChars' => 0,
@@ -87,3 +89,4 @@ class InteractiveOptionsProvider implements InteractiveOptionsProviderInterface
         ];
     }
 }
+

--- a/Test/Integration/Block/ThemeV2/PageOutputTest.php
+++ b/Test/Integration/Block/ThemeV2/PageOutputTest.php
@@ -56,7 +56,7 @@ class PageOutputTest extends AbstractControllerTestCase
                 'Initialisation script is present in response body'
             );
             $this->assertStringContainsString(
-                '"url":{"landing":"\/search"',
+                '"url":{"protocol":"https","landing":"\/search"',
                 $responseBody,
                 'JS options contain landing page URL'
             );
@@ -72,7 +72,7 @@ class PageOutputTest extends AbstractControllerTestCase
                 'Initialisation script is present in response body'
             );
             $this->assertContains(
-                '"url":{"landing":"\/search"',
+                '"url":{"protocol":"https","landing":"\/search"',
                 $responseBody,
                 'JS options contain landing page URL'
             );
@@ -160,7 +160,7 @@ class PageOutputTest extends AbstractControllerTestCase
                 'Initialisation script is present in response body'
             );
             $this->assertStringNotContainsString(
-                '"url":{"landing":"\/search"',
+                '"url":{"protocol":"https","landing":"\/search"',
                 $responseBody,
                 'JS options contain landing page URL'
             );
@@ -176,7 +176,7 @@ class PageOutputTest extends AbstractControllerTestCase
                 'Initialisation script is present in response body'
             );
             $this->assertNotContains(
-                '"url":{"landing":"\/search"',
+                '"url":{"protocol":"https","landing":"\/search"',
                 $responseBody,
                 'JS options contain landing page URL'
             );
@@ -240,7 +240,7 @@ class PageOutputTest extends AbstractControllerTestCase
                 'Initialisation script is present in response body'
             );
             $this->assertStringNotContainsString(
-                '"url":{"landing":"\/search"',
+                '"url":{"protocol":"https","landing":"\/search"',
                 $responseBody,
                 'JS options contain landing page URL'
             );
@@ -256,7 +256,7 @@ class PageOutputTest extends AbstractControllerTestCase
                 'Initialisation script is present in response body'
             );
             $this->assertNotContains(
-                '"url":{"landing":"\/search"',
+                '"url":{"protocol":"https","landing":"\/search"',
                 $responseBody,
                 'JS options contain landing page URL'
             );
@@ -321,7 +321,7 @@ class PageOutputTest extends AbstractControllerTestCase
                 'Initialisation script is present in response body'
             );
             $this->assertStringNotContainsString(
-                '"url":{"landing":"\/search"',
+                '"url":{"protocol":"https","landing":"\/search"',
                 $responseBody,
                 'JS options contain landing page URL'
             );
@@ -337,7 +337,7 @@ class PageOutputTest extends AbstractControllerTestCase
                 'Initialisation script is present in response body'
             );
             $this->assertNotContains(
-                '"url":{"landing":"\/search"',
+                '"url":{"protocol":"https","landing":"\/search"',
                 $responseBody,
                 'JS options contain landing page URL'
             );

--- a/Test/Integration/Service/ThemeV2/InteractiveOptionsProviderTest.php
+++ b/Test/Integration/Service/ThemeV2/InteractiveOptionsProviderTest.php
@@ -42,8 +42,9 @@ class InteractiveOptionsProviderTest extends TestCase
 
         $expectedResult = [
             'url' => [
+                'protocol' => 'https',
                 'landing' => '/search',
-                'search' => '//eucs999v2.klevu.com/cs/v2/search',
+                'search' => 'https://eucs999v2.klevu.com/cs/v2/search',
             ],
             'search' => [
                 'minChars' => 0,
@@ -85,8 +86,9 @@ class InteractiveOptionsProviderTest extends TestCase
 
         $expectedResult = [
             'url' => [
+                'protocol' => 'https',
                 'landing' => '/catalogsearch/result',
-                'search' => '//eucs999v2.klevu.com/cs/v2/search',
+                'search' => 'https://eucs999v2.klevu.com/cs/v2/search',
             ],
             'search' => [
                 'minChars' => 0,
@@ -172,3 +174,4 @@ class InteractiveOptionsProviderTest extends TestCase
         return $isEnabledConditionMock;
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "klevu/module-metadata": "^1.1.0"
     },
     "type": "magento-module",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
It is to enable indexing of products with Klevu Search. This is a mandatory package.

Please, see klevu-smart-search-M2/README.md for more information on how to install the overall extension.