### PR TITLE
Allow use of 'use system value' feature

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field.php
+++ b/Block/Adminhtml/System/Config/Form/Field.php
@@ -217,32 +217,6 @@ class Field extends \Magento\Config\Block\System\Config\Form\Field
     }
 
     /**
-     * Check if inheritance checkbox has to be rendered
-     *
-     * @param \Magento\Framework\Data\Form\Element\AbstractElement $element
-     * @return bool
-     */
-    protected function _isInheritCheckboxRequired(\Magento\Framework\Data\Form\Element\AbstractElement $element)
-    {
-        return $element->getCanUseWebsiteValue() || $element->getCanUseDefaultValue();
-    }
-
-    /**
-     * Retrieve label for the inheritance checkbox
-     *
-     * @param \Magento\Framework\Data\Form\Element\AbstractElement $element
-     * @return string
-     */
-    protected function _getInheritCheckboxLabel(\Magento\Framework\Data\Form\Element\AbstractElement $element)
-    {
-        $checkboxLabel = __('Use Default');
-        if ($element->getCanUseWebsiteValue()) {
-            $checkboxLabel = __('Use Website');
-        }
-        return $checkboxLabel;
-    }
-
-    /**
      * Render scope label
      *
      * @param \Magento\Framework\Data\Form\Element\AbstractElement $element


### PR DESCRIPTION
This module currently makes it impossible to use the "use system value" check-box. This means that a lot of unnecessary values are stored in `core_config_data`. I see no reason why this feature should be removed by this module. Removing these two function overrides restores the expected functionality.

I recommend that this whole module is reviewed for best practices as there are many other problems that I noticed while debugging this issue on one of our websites.