### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "klevu/module-metadata": "^1.1.0"
     },
     "type": "magento-module",
-    "version": "2.6.1-beta",
+    "version": "2.6.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
It is to enable indexing of products with Klevu Search. This is a mandatory package.
Please, see klevu-smart-search-M2/README.md for more information on how to install the overall extension.