### PR TITLE
Enhancement: Detach from default cron group

### DIFF
--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
+    <group id="klevu_cron">
+        <schedule_generate_every>15</schedule_generate_every>
+        <schedule_ahead_for>20</schedule_ahead_for>
+        <schedule_lifetime>20</schedule_lifetime>
+        <history_cleanup_every>10</history_cleanup_every>
+        <history_success_lifetime>180</history_success_lifetime>
+        <history_failure_lifetime>4320</history_failure_lifetime>
+        <use_separate_process>1</use_separate_process>
+    </group>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
-    <group id="default">
+    <group id="klevu_cron">
         <job name="klevu_search_product_sync" instance="Klevu\Search\Model\Product\Sync" method="runCron">
             <config_path>klevu_search/product_sync/frequency</config_path>
         </job>


### PR DESCRIPTION
Detach Klevu cron jobs from the default cron group to make them independent from general jobs

Detaching also can ensure that the jobs will be triggered/started (instead of the default cron job getting stopped prematurely by any previous job resulting Klevu's job never being triggered) every time

`use_separate_process` can ensure that no other jobs will be handled by the dedicated cron process started for the new group

created as per https://help.klevu.com/support/tickets/59609 closed without any feedback