### PR TITLE
Switch to laminas http

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -37,7 +37,7 @@ use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Tax\Model\Config as MagentoTaxConfig;
-use Zend\Http\Client\Exception\RuntimeException;
+use Laminas\Http\Client\Exception\RuntimeException;
 
 class Config extends AbstractHelper
 {

--- a/Model/Api/Request.php
+++ b/Model/Api/Request.php
@@ -58,7 +58,7 @@ class Request extends \Magento\Framework\DataObject
     {
         parent::_construct();
 
-        $this->method = \Zend\Http\Client::GET;
+        $this->method = \Laminas\Http\Client::GET;
         $this->headers = [];
         $this->response_model = $this->_modelApiResponse;
     }
@@ -187,7 +187,7 @@ class Request extends \Magento\Framework\DataObject
         }
         try {
             $raw_response = $raw_request->send();
-        } catch (\Zend\Http\Client\Exception $e) {
+        } catch (\Laminas\Http\Client\Exception $e) {
             // Return an empty response
             $this->_searchHelperData->log(
                 LoggerConstants::ZEND_LOG_ERR,
@@ -239,11 +239,11 @@ class Request extends \Magento\Framework\DataObject
     /**
      * Build the HTTP request to be sent.
      *
-     * @return \Zend\Http\Client
+     * @return \Laminas\Http\Client
      */
     protected function build()
     {
-        $client = ObjectManager::getInstance()->get('Zend\Http\Client');
+        $client = ObjectManager::getInstance()->get(\Laminas\Http\Client::class);
         if (!empty($this->getHeaders())) {
             $client
                 ->setUri($this->getEndpoint())

--- a/Model/Api/Request/Get.php
+++ b/Model/Api/Request/Get.php
@@ -22,14 +22,14 @@ class Get extends \Klevu\Search\Model\Api\Request
     /**
      * Add GET parameters to the request, force GET method.
      *
-     * @return \Zend\Http\Client
+     * @return \Laminas\Http\Client
      */
     protected function build()
     {
         $client = parent::build();
 
         $client
-            ->setMethod(\Zend\Http\Request::METHOD_GET)
+            ->setMethod(\Laminas\Http\Request::METHOD_GET)
             ->setParameterGet($this->getData());
 
         return $client;

--- a/Model/Api/Request/Post.php
+++ b/Model/Api/Request/Post.php
@@ -30,14 +30,14 @@ class Post extends \Klevu\Search\Model\Api\Request
     /**
      * Add POST parameters to the request, force POST method.
      *
-     * @return \Zend\Http\Client
+     * @return \Laminas\Http\Client
      */
     protected function build()
     {
         $client = parent::build();
 
         $client
-            ->setMethod(\Zend\Http\Request::METHOD_POST)
+            ->setMethod(\Laminas\Http\Request::METHOD_POST)
             ->setParameterPost($this->getData());
 
         return $client;

--- a/Model/Api/Request/Xml.php
+++ b/Model/Api/Request/Xml.php
@@ -4,7 +4,7 @@ namespace Klevu\Search\Model\Api\Request;
 
 use Klevu\Search\Model\Api\Request;
 use Magento\Framework\App\ObjectManager;
-use Zend\Http\Client;
+use Laminas\Http\Client;
 
 class Xml extends Request
 {

--- a/Model/Api/Response.php
+++ b/Model/Api/Response.php
@@ -47,11 +47,11 @@ class Response extends \Magento\Framework\DataObject
     /**
      * Set the raw response object representing this API response.
      *
-     * @param \Zend\Http\Response $response
+     * @param \Laminas\Http\Response $response
      *
      * @return $this
      */
-    public function setRawResponse(\Zend\Http\Response $response)
+    public function setRawResponse(\Laminas\Http\Response $response)
     {
         $this->raw_response = $response;
 
@@ -83,11 +83,11 @@ class Response extends \Magento\Framework\DataObject
     /**
      * Extract the API response data from the given HTTP response object.
      *
-     * @param \Zend\Http\Response $response
+     * @param \Laminas\Http\Response $response
      *
      * @return $this
      */
-    protected function parseRawResponse(\Zend\Http\Response $response)
+    protected function parseRawResponse(\Laminas\Http\Response $response)
     {
         if ($response->isSuccess()) {
             $content = $response->getBody();

--- a/Model/Api/Response/Data.php
+++ b/Model/Api/Response/Data.php
@@ -5,7 +5,7 @@ namespace Klevu\Search\Model\Api\Response;
 class Data extends \Klevu\Search\Model\Api\Response
 {
 
-    protected function parseRawResponse(\Zend\Http\Response $response)
+    protected function parseRawResponse(\Laminas\Http\Response $response)
     {
         parent::parseRawResponse($response);
 

--- a/Model/Api/Response/Invalid.php
+++ b/Model/Api/Response/Invalid.php
@@ -54,11 +54,11 @@ class Invalid extends \Klevu\Search\Model\Api\Response
     /**
      * Override the parse response method, this API response is doesn't use HTTP.
      *
-     * @param \Zend\Http\Response $response
+     * @param \Laminas\Http\Response $response
      *
      * @return $this
      */
-    protected function parseRawResponse(\Zend\Http\Response $response)
+    protected function parseRawResponse(\Laminas\Http\Response $response)
     {
         // Do nothing
         return $this;

--- a/Model/Api/Response/Message.php
+++ b/Model/Api/Response/Message.php
@@ -5,7 +5,7 @@ namespace Klevu\Search\Model\Api\Response;
 class Message extends \Klevu\Search\Model\Api\Response
 {
 
-    protected function parseRawResponse(\Zend\Http\Response $response)
+    protected function parseRawResponse(\Laminas\Http\Response $response)
     {
         parent::parseRawResponse($response);
 

--- a/Model/Api/Response/Rempty.php
+++ b/Model/Api/Response/Rempty.php
@@ -16,11 +16,11 @@ class Rempty extends \Klevu\Search\Model\Api\Response
     /**
      * Override the parse response method, this API response is static.
      *
-     * @param \Zend\Http\Response $response
+     * @param \Laminas\Http\Response $response
      *
      * @return $this
      */
-    protected function parseRawResponse(\Zend\Http\Response $response)
+    protected function parseRawResponse(\Laminas\Http\Response $response)
     {
         // Do nothing
         return $this;

--- a/Model/Api/Response/Search.php
+++ b/Model/Api/Response/Search.php
@@ -5,7 +5,7 @@ namespace Klevu\Search\Model\Api\Response;
 class Search extends \Klevu\Search\Model\Api\Response
 {
 
-    protected function parseRawResponse(\Zend\Http\Response $response)
+    protected function parseRawResponse(\Laminas\Http\Response $response)
     {
         parent::parseRawResponse($response);
 

--- a/Model/Api/Response/Timezone.php
+++ b/Model/Api/Response/Timezone.php
@@ -5,7 +5,7 @@ namespace Klevu\Search\Model\Api\Response;
 class Timezone extends \Klevu\Search\Model\Api\Response\Data
 {
 
-    protected function parseRawResponse(\Zend\Http\Response $response)
+    protected function parseRawResponse(\Laminas\Http\Response $response)
     {
         parent::parseRawResponse($response);
 

--- a/Test/Integration/Helper/ApiTest.php
+++ b/Test/Integration/Helper/ApiTest.php
@@ -321,11 +321,11 @@ class ApiTest extends TestCase
     private function getApiResponseMock($success, $responseXml)
     {
         if (method_exists($this, 'createMock')) {
-            $zendResponseMock = $this->createMock(\Zend\Http\Response::class);
+            $zendResponseMock = $this->createMock(\Laminas\Http\Response::class);
             $zendResponseMock->method('isSuccess')->willReturn($success);
             $zendResponseMock->method('getBody')->willReturn($responseXml);
         } else {
-            $zendResponseMock = $this->getMockBuilder(\Zend\Http\Response::class)
+            $zendResponseMock = $this->getMockBuilder(\Laminas\Http\Response::class)
                 ->disableOriginalConstructor()
                 ->getMock();
             $zendResponseMock->expects($this->any())

--- a/Test/Integration/Model/Product/Sync/XmlBodyTest.php
+++ b/Test/Integration/Model/Product/Sync/XmlBodyTest.php
@@ -55,7 +55,7 @@ class XmlBodyTest extends TestCase
     private $baseUrl = '';
 
     /**
-     * @var MockObject&\Zend\Http\Client
+     * @var MockObject&\Laminas\Http\Client
      */
     private $clientMock;
 
@@ -676,7 +676,7 @@ class XmlBodyTest extends TestCase
         $backendSession = $this->objectManager->get(Session::class);
         $backendSession->setKlevuSessionId(self::SESSION_ID_FIXTURE);
 
-        $mockClientBuilder = $this->getMockBuilder('Zend\Http\Client');
+        $mockClientBuilder = $this->getMockBuilder(\Laminas\Http\Client::class);
         if (method_exists($mockClientBuilder, 'onlyMethods')) {
             $mockClientBuilder->onlyMethods(['setRawBody', 'send']);
         } else {
@@ -688,10 +688,10 @@ class XmlBodyTest extends TestCase
 
         $this->clientMock->method('send')
             ->willReturnCallback(function (Request $request = null) {
-                return $this->objectManager->create('Zend\Http\Response');
+                return $this->objectManager->create(\Laminas\Http\Response::class);
             });
 
-        $this->objectManager->addSharedInstance($this->clientMock, 'Zend\Http\Client');
+        $this->objectManager->addSharedInstance($this->clientMock, \Laminas\Http\Client::class);
     }
 
     /**
@@ -789,7 +789,7 @@ class XmlBodyTest extends TestCase
     {
         include __DIR__ . '/_files/productFixturesXmlBody_rollback.php';
     }
-    
+
     /**
      * @param string $needle
      * @param string $haystack

--- a/Test/Integration/Service/Account/GetFeatures/GetAccountFeaturesServiceXmlTest.php
+++ b/Test/Integration/Service/Account/GetFeatures/GetAccountFeaturesServiceXmlTest.php
@@ -312,18 +312,18 @@ XML
         $this->objectManager = ObjectManager::getInstance();
 
         $this->httpClientResponseMock['https://tiers.klevu.com/uti/getFeaturesAndUpgradeLink'] =
-            $this->getMockBuilder('Zend\Http\Response')
+            $this->getMockBuilder('Laminas\Http\Response')
                 ->disableOriginalConstructor()
                 ->setMethods(['getBody'])
                 ->getMock();
 
         $this->httpClientResponseMock['https://tiers.klevu.com/uti/getFeatureValues'] =
-            $this->getMockBuilder('Zend\Http\Response')
+            $this->getMockBuilder('Laminas\Http\Response')
                 ->disableOriginalConstructor()
                 ->setMethods(['getBody'])
                 ->getMock();
 
-        $this->httpClientMock = $this->getMockBuilder('Zend\Http\Client')
+        $this->httpClientMock = $this->getMockBuilder('Laminas\Http\Client')
             ->disableOriginalConstructor()
             ->setMethods(['setParameterPost', 'setUri', 'send'])
             ->getMock();
@@ -355,7 +355,7 @@ XML
             ->willReturnCallback(function () {
                 return $this->httpClientResponseMock[$this->httpClientCurrentEndpoint];
             });
-        $this->objectManager->addSharedInstance($this->httpClientMock, 'Zend\Http\Client');
+        $this->objectManager->addSharedInstance($this->httpClientMock, 'Laminas\Http\Client');
     }
 
     /**

--- a/Test/Unit/Model/Api/RequestSendLoggingTest.php
+++ b/Test/Unit/Model/Api/RequestSendLoggingTest.php
@@ -120,13 +120,13 @@ class RequestSendLoggingTest extends TestCase
     }
 
     /**
-     * @return \Laminas\Http\Client|\Zend\Http\Client|MockObject
+     * @return \Laminas\Http\Client|\Laminas\Http\Client|MockObject
      */
     private function getMockClient()
     {
         $responseFqcn = class_exists('\Laminas\Http\Response')
             ? \Laminas\Http\Response::class
-            : \Zend\Http\Response::class;
+            : \Laminas\Http\Response::class;
 
         $mockClientResponse = $this->getMockBuilder($responseFqcn)
             ->disableOriginalConstructor()
@@ -134,7 +134,7 @@ class RequestSendLoggingTest extends TestCase
 
         $clientFqcn = class_exists('\Laminas\Http\Client')
             ? \Laminas\Http\Client::class
-            : \Zend\Http\Client::class;
+            : \Laminas\Http\Client::class;
         $mockClient = $this->getMockBuilder($clientFqcn)
             ->disableOriginalConstructor()
             ->getMock();

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "magento/framework": ">=102.0.0",
         "klevu/module-logger": "^1.0.0|^2.0.0",
         "klevu/module-frontend-js": "^2.0.0",
-        "klevu/module-metadata": "^1.4.1"
+        "klevu/module-metadata": "^1.4.1",
+        "laminas/laminas-http": "^2.15"
     },
     "suggest": {
         "klevu/module-msi": "Add support for MSI during product sync"


### PR DESCRIPTION
laminas/laminas-server (2.17.0) drops requirement for laminas/laminas-zendframework-bridge (which is abandoned now)