### PR TITLE
Fix: update console command execute() method signatures for Magento 2.4.9

### DIFF
--- a/Console/Command/ImageGeneration.php
+++ b/Console/Command/ImageGeneration.php
@@ -123,7 +123,7 @@ HELP
      * @return bool|int
      * @throws \Magento\Framework\Exception\FileSystemException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $logDir = $this->_directoryList->getPath(DirectoryList::VAR_DIR);
         $areacodeFile = $logDir . "/" . self::AREA_CODE_LOCK_FILE;

--- a/Console/Command/RatingGeneration.php
+++ b/Console/Command/RatingGeneration.php
@@ -113,7 +113,7 @@ HELP
      * @return bool|int
      * @throws \Magento\Framework\Exception\FileSystemException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $logDir = $this->_directoryList->getPath(DirectoryList::VAR_DIR);
         $areacodeFile = $logDir . "/" . self::AREA_CODE_LOCK_FILE;

--- a/Console/Command/SyncCategoryCommand.php
+++ b/Console/Command/SyncCategoryCommand.php
@@ -138,7 +138,7 @@ HELP
      *
      * @return void
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // See comments against methods for background. Ref: KS-7853
         $this->initLogger();

--- a/Console/Command/SyncCommand.php
+++ b/Console/Command/SyncCommand.php
@@ -144,7 +144,7 @@ HELP
         parent::configure();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // See comments against methods for background. Ref: KS-7853
         $this->initLogger();

--- a/Console/Command/SyncOrderCommand.php
+++ b/Console/Command/SyncOrderCommand.php
@@ -108,7 +108,7 @@ Send order records which have not yet been synced with Klevu for stores with cod
      * @param OutputInterface $output
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // See comments against methods for background. Ref: KS-7853
         $this->initLogger();

--- a/Console/Command/SyncOrderCommand.php
+++ b/Console/Command/SyncOrderCommand.php
@@ -94,10 +94,10 @@ class SyncOrderCommand extends Command
         $this->setHelp('
 Send order records which have not yet been synced with Klevu for all enabled stores
     <comment>%command.full_name%</comment>
-    
+
 Send order records which have not yet been synced with Klevu for store with code "default"
     <comment>%command.full_name% --store default</comment>
-    
+
 Send order records which have not yet been synced with Klevu for stores with codes "default" and "new_store"
     <comment>%command.full_name% --store default --store new_store</comment>
         ');

--- a/Console/Command/SyncStoreView.php
+++ b/Console/Command/SyncStoreView.php
@@ -143,7 +143,7 @@ HELP
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // See comments against methods for background. Ref: KS-7853
         $this->initLogger();

--- a/Console/Command/UserCreation.php
+++ b/Console/Command/UserCreation.php
@@ -107,7 +107,7 @@ HELP
      * @return int
      * @deprecated Use Klevu Merchant Center (https://box.klevu.com/analytics) to create stores and manage your users.
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('');
         $output->writeln('<info>This feature has been depreciated from CLI.</info>');


### PR DESCRIPTION
This pull request updates the method signatures for the `execute` methods in several console command classes to explicitly declare their return type as `int`. This change is required for Magento 2.4.9 because they updated symfony/console to ^7.4.
In this version, the method signature looks like this:
```
protected function execute(InputInterface $input, OutputInterface $output): int
```

**Type declaration improvements:**

* Updated the `execute` method signature to return `int` in the following command classes:
  - `Console/Command/ImageGeneration.php`
  - `Console/Command/RatingGeneration.php`
  - `Console/Command/SyncCategoryCommand.php`
  - `Console/Command/SyncCommand.php`
  - `Console/Command/SyncOrderCommand.php`
  - `Console/Command/SyncStoreView.php`
  - `Console/Command/UserCreation.php`

The change is backward compatible; it works in old Magento versions.